### PR TITLE
Development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['10', '12', '13', '14']
+        node-version: ['10', '12', '14']
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -28,4 +28,4 @@ jobs:
       if: ${{ matrix.node-version == '14' }}
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage/clover.xml
+        file: ./coverage/lcov.info

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  coverageReporters: ['clover'],
+  coverageReporters: ['lcov'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luthier",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Luthier handles all of your string needs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Not entirely sure why, but the clover report was reporting some gaps in
coverage. These gaps actually didn't make much sense (all conditions
were green, but the top conditional was not). Suspect perhaps related to
TypeScript.
    
Went ahead and swapped clover for lcov and coverage went back to 100%.
Also dropped Node v13.x as it's past it's expiration date.